### PR TITLE
Create autocompletion for dpkg-reconfigure

### DIFF
--- a/share/completions/dpkg-reconfigure.fish
+++ b/share/completions/dpkg-reconfigure.fish
@@ -1,0 +1,14 @@
+# Completions for the `dpkg-reconfigure` command
+
+complete -f -c dpkg-reconfigure -a '(__fish_print_packages)' --description 'Package'
+
+# Support flags
+complete -x -f -c dpkg-reconfigure -s h -l help     --description 'Display help'
+
+# General options
+complete -f -c dpkg-reconfigure -s f -l frontend -r -a "dialog readline noninteractive gnome kde editor web" --description 'Set configuration frontend'
+complete -f -c dpkg-reconfigure -s p -l priority -r -a "low medium high critical" --description 'Set priority threshold'
+complete -f -c dpkg-reconfigure -l default-priority --description 'Use default priority threshold'
+complete -f -c dpkg-reconfigure -s u -l unseen-only --description 'Show only unseen question'
+complete -f -c dpkg-reconfigure -l force --description 'Reconfigure also inconsistent packages'
+complete -f -c dpkg-reconfigure -l no-reload --description 'Prevent reloading templates'


### PR DESCRIPTION
The dpkg-reconfigure command is used on Debian and Ubuntu based systems to reconfigure packages.

According to the relevant manpages the commited completion file should be feature-complete.